### PR TITLE
Update connector contract to protect delivery-ack window with certainty

### DIFF
--- a/internal/events/eventstream.go
+++ b/internal/events/eventstream.go
@@ -549,6 +549,7 @@ func (u *PreparedListenerUpdate) Apply(ctx context.Context) error {
 
 func (es *eventStream) resetListenerCheckpoint(ctx context.Context, l *listener) error {
 	l.checkpoint = nil
+	l.checkpointSource = checkpointSourceEvent
 	l.lastCheckpoint = nil
 	cp, err := es.checkpointsDB.GetCheckpoint(ctx, es.spec.ID)
 	if err != nil || cp == nil {
@@ -873,6 +874,17 @@ func (es *eventStream) eventLoop(startedState *startedStreamState) {
 	}
 }
 
+func (es *eventStream) getListenerWithCheckpoint(listenerID *fftypes.UUID) (l *listener, currentCheckpoint ffcapi.EventListenerCheckpoint, cpSource checkpointSource) {
+	es.mux.Lock()
+	defer es.mux.Unlock()
+	l = es.listeners[*listenerID]
+	if l != nil {
+		currentCheckpoint = l.checkpoint
+		cpSource = l.checkpointSource
+	}
+	return
+}
+
 func (es *eventStream) checkConfirmedEventForBatch(e *ffcapi.ListenerEvent) (l *listener, ewc *apitypes.EventWithContext) {
 	var eToLog fmt.Stringer
 	var listenerID *fftypes.UUID
@@ -887,23 +899,28 @@ func (es *eventStream) checkConfirmedEventForBatch(e *ffcapi.ListenerEvent) (l *
 		log.L(es.bgCtx).Errorf("Invalid event cannot be dispatched: %+v", e)
 		return nil, nil
 	}
-	es.mux.Lock()
-	l = es.listeners[*listenerID]
-	es.mux.Unlock()
+	l, currentCheckpoint, cpSource := es.getListenerWithCheckpoint(listenerID)
 	if l == nil {
 		log.L(es.bgCtx).Warnf("Confirmed event not associated with any active listener: %s", eToLog)
 		return nil, nil
 	}
-	currentCheckpoint := l.checkpoint
 	if currentCheckpoint != nil && !currentCheckpoint.LessThan(e.Checkpoint) {
-		// This event is behind the current checkpoint - this is a re-detection.
-		// We're perfectly happy to accept re-detections from the connector, as it can be
-		// very efficient to batch operations between listeners that cause re-detections.
-		// However, we need to protect the application from receiving the re-detections.
-		// This loop is the right place for this check, as we are responsible for writing the checkpoints and
-		// delivering to the application. So we are the one source of truth.
-		log.L(es.bgCtx).Debugf("%s '%s' event re-detected behind checkpoint: %s", l.spec.ID, l.spec.SignatureString(), eToLog)
-		return nil, nil
+		if cpSource == checkpointSourceHWM {
+			// The checkpoint holding this event back is the connector's scan position, not the position
+			// of an event the receiver acked. So it does not tell us we already delivered this one, and
+			// we cannot tell a re-detection apart from an event emitted before, but arriving after, we
+			// applied that scan position.
+			// Unsafe to assume this is a re-detection, so we deliver.
+			log.L(es.bgCtx).Warnf("%s '%s' event behind high water mark checkpoint %+v - delivering rather than discarding: %s", l.spec.ID, l.spec.SignatureString(), currentCheckpoint, eToLog)
+		} else {
+			// This event is behind the position of an event the receiver acked, so we know we already
+			// delivered it - this is a re-detection.
+			// We're perfectly happy to accept re-detections from the connector, as it can be
+			// very efficient to batch operations between listeners that cause re-detections.
+			// However, we protect the application from receiving the re-detections in this case.
+			log.L(es.bgCtx).Debugf("%s '%s' event re-detected behind checkpoint: %s", l.spec.ID, l.spec.SignatureString(), eToLog)
+			return nil, nil
+		}
 	}
 	if e.Event != nil {
 		ewc = &apitypes.EventWithContext{
@@ -1119,35 +1136,59 @@ func (es *eventStream) checkUpdateHWMCheckpoint(ctx context.Context, l *listener
 
 	checkpoint := l.checkpoint
 
-	inFlight := false
-	if es.confirmationsRequired > 0 {
-		inFlight = es.confirmations.CheckInFlight(l.spec.ID)
+	// We first ask the connector for their view of the checkpoint for this stream, and then
+	// check against our state to determine if it's safe to apply.
+	res, _, err := es.connector.EventListenerHWM(ctx, &ffcapi.EventListenerHWMRequest{
+		StreamID:   es.spec.ID,
+		ListenerID: l.spec.ID,
+	})
+	if err != nil {
+		log.L(ctx).Errorf("Failed to obtain high watermark checkpoint for listener '%s': %s", l.spec.ID, err)
+		return checkpoint
 	}
 
-	// If there's in-flight messages in the confirmation manager, we wait for these to be confirmed or purged before
-	// writing a checkpoint.
-	if inFlight {
-		log.L(ctx).Infof("Stale checkpoint for listener '%s' will not be updated as events are in-flight", l.spec.ID)
-	} else {
-		res, _, err := es.connector.EventListenerHWM(ctx, &ffcapi.EventListenerHWMRequest{
-			StreamID:   es.spec.ID,
-			ListenerID: l.spec.ID,
-		})
-		if err != nil {
-			log.L(ctx).Errorf("Failed to obtain high watermark checkpoint for listener '%s': %s", l.spec.ID, err)
-			return checkpoint
-		}
-		es.mux.Lock()
-		if l.checkpoint == checkpoint /* double check it hasn't changed */ {
-			checkpoint = res.Checkpoint
-			l.checkpoint = checkpoint
-			l.lastCheckpoint = fftypes.Now()
-		}
-		es.mux.Unlock()
+	es.mux.Lock()
+	defer es.mux.Unlock()
+
+	// Factor in in-flight deliveries (whether waiting for confirmations, or ack from the app)
+	// when determining if the connectors updated checkpoint is safe to apply.
+	if !es.lockedHWMSafeToApply(ctx, l, res) {
+		return checkpoint
+	}
+
+	if l.checkpoint == checkpoint /* double check it hasn't changed */ {
+		checkpoint = res.Checkpoint
+		l.checkpoint = checkpoint
+		l.checkpointSource = checkpointSourceHWM
+		l.lastCheckpoint = fftypes.Now()
 	}
 
 	return checkpoint
 
+}
+
+func (es *eventStream) lockedHWMSafeToApply(ctx context.Context, l *listener, res *ffcapi.EventListenerHWMResponse) bool {
+	if res.LastDetected != nil {
+		// If l.checkpoint (the point we've committed to already based on acks and earlier HWM)
+		// is below the last detection point, it's not safe to move it forwards.
+		// We're waiting for the next ack to arrive (or LastDetected to change on the connector side).
+		if l.checkpoint == nil || l.checkpoint.LessThan(res.LastDetected) {
+			log.L(ctx).Debugf("Stale checkpoint for listener '%s' will not be updated - connector has detected to %+v, we have committed to %+v",
+				l.spec.ID, res.LastDetected, l.checkpoint)
+			return false
+		}
+		return true
+	}
+	// No detection point reported. Either the connector does not implement it, or it has detected
+	// nothing yet for this listener. For example during a long catchup scan that has not matched anything.
+	// Note: for a connector that doesn't implement LastDetected, an event still inside FFTM can end up
+	//       behind a high water mark we applied. We can't distinguish that from a re-detection, so
+	//       checkConfirmedEventForBatch fails safe and redelivers rather than discarding.
+	if es.confirmations.CheckInFlight(l.spec.ID) {
+		log.L(ctx).Debugf("Stale checkpoint for listener '%s' will not be updated as events are in-flight", l.spec.ID)
+		return false
+	}
+	return true
 }
 
 func (es *eventStream) generateCheckpoint(startedState *startedStreamState, batch *eventStreamBatch) *apitypes.EventStreamCheckpoint {
@@ -1164,6 +1205,7 @@ func (es *eventStream) generateCheckpoint(startedState *startedStreamState, batc
 		for lID, lCP := range batch.checkpoints {
 			if l, ok := es.listeners[lID]; ok {
 				l.checkpoint = lCP
+				l.checkpointSource = checkpointSourceEvent // this is the position of an event the receiver has acked
 				l.lastCheckpoint = startedState.lastCheckpoint
 				log.L(es.bgCtx).Tracef("%s (%s) checkpoint: %+v", l.spec.SignatureString(), l.spec.ID, lCP)
 			}
@@ -1176,8 +1218,11 @@ func (es *eventStream) generateCheckpoint(startedState *startedStreamState, batc
 			cp.Listeners[lID], _ = json.Marshal(l.checkpoint)
 		}
 		// Add all started listeners with non-existent or stale checkpoints to the stale list,
-		// which we query below after we've dropped the lock
-		if l.started && (l.checkpoint == nil || l.lastCheckpoint == nil || time.Since(*l.lastCheckpoint.Time()) > es.checkpointInterval) {
+		// which we query below after we've dropped the lock.
+		// Block listeners are excluded - they are handled entirely inside our own confirmation manager,
+		// are never passed to the connector, and their checkpoint advances with every block event.
+		isBlockListener := l.spec.Type != nil && *l.spec.Type == apitypes.ListenerTypeBlocks
+		if l.started && !isBlockListener && (l.checkpoint == nil || l.lastCheckpoint == nil || time.Since(*l.lastCheckpoint.Time()) > es.checkpointInterval) {
 			staleCheckpoints = append(staleCheckpoints, l)
 		}
 	}

--- a/internal/events/eventstream_test.go
+++ b/internal/events/eventstream_test.go
@@ -609,7 +609,8 @@ func TestAPIManagedEventStreamE2E(t *testing.T) {
 		}
 	}).Return(nil)
 	mcm.On("StopConfirmedBlockListener", mock.Anything, l.ID).Return(nil)
-	mcm.On("CheckInFlight", l.ID).Return(true) // simulate in-flight to prevent checking HWM
+	// Note no CheckInFlight stub - a block listener is never passed to the connector, so a checkpoint
+	// cycle does not take the high water mark route for it
 
 	mfc.On("EventStreamStart", mock.Anything, mock.MatchedBy(func(r *ffcapi.EventStreamStartRequest) bool {
 		return r.ID.Equals(es.spec.ID)
@@ -2138,6 +2139,7 @@ func TestHWMCheckpointInFlightSkip(t *testing.T) {
 		started: true,
 	}
 
+	// Legacy connector - reports no LastDetected, so we fall back to the confirmation manager
 	mcm := &confirmationsmocks.Manager{}
 	mcm.On("CheckInFlight", li.spec.ID).Run(func(args mock.Arguments) {
 		ss.cancelCtx()
@@ -2145,6 +2147,11 @@ func TestHWMCheckpointInFlightSkip(t *testing.T) {
 	es.confirmations = mcm
 	es.confirmationsRequired = 1
 	es.listeners[*li.spec.ID] = li
+
+	mfc := es.connector.(*ffcapimocks.API)
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{
+		Checkpoint: &utCheckpointType{SomeSequenceNumber: 12345},
+	}, ffcapi.ErrorReason(""), nil)
 
 	msp := es.checkpointsDB.(*persistencemocks.Persistence)
 	msp.On("WriteCheckpoint", mock.Anything, mock.MatchedBy(func(cp *apitypes.EventStreamCheckpoint) bool {
@@ -2157,6 +2164,8 @@ func TestHWMCheckpointInFlightSkip(t *testing.T) {
 
 	es.batchLoop(ss)
 
+	assert.Nil(t, li.checkpoint)
+	mfc.AssertExpectations(t)
 	msp.AssertExpectations(t)
 	mcm.AssertExpectations(t)
 }
@@ -2178,8 +2187,9 @@ func TestHWMCheckpointFail(t *testing.T) {
 		started: true,
 	}
 
+	// The query fails, so we never get as far as deciding whether the answer is safe to apply -
+	// no call is made to the confirmation manager
 	mcm := &confirmationsmocks.Manager{}
-	mcm.On("CheckInFlight", li.spec.ID).Return(false)
 	es.confirmations = mcm
 	es.confirmationsRequired = 1
 	es.listeners[*li.spec.ID] = li
@@ -2205,6 +2215,263 @@ func TestHWMCheckpointFail(t *testing.T) {
 	mfc.AssertExpectations(t)
 	msp.AssertExpectations(t)
 	mcm.AssertExpectations(t)
+}
+
+// newHWMTestListener builds a started listener with a stale checkpoint, so that a checkpoint cycle
+// takes the high water mark route for it
+func newHWMTestListener(es *eventStream, checkpoint ffcapi.EventListenerCheckpoint) *listener {
+	li := &listener{
+		es:         es,
+		spec:       &apitypes.Listener{ID: fftypes.NewUUID(), Name: strPtr("ut_listener")},
+		started:    true,
+		checkpoint: checkpoint,
+	}
+	// A long interval with a nil lastCheckpoint forces staleness deterministically - a short interval
+	// makes the checkpoint written inside generateCheckpoint itself stale within the same call
+	es.checkpointInterval = 1 * time.Hour
+	es.listeners[*li.spec.ID] = li
+	return li
+}
+
+func TestHWMNotAppliedWhenConnectorHasDetectedAhead(t *testing.T) {
+
+	es := newTestEventStream(t, `{
+		"name": "ut_stream"
+	}`)
+
+	ss := &startedStreamState{}
+	ss.ctx, ss.cancelCtx = context.WithCancel(context.Background())
+	defer ss.cancelCtx()
+
+	li := newHWMTestListener(es, &utCheckpointType{SomeSequenceNumber: 4900})
+
+	// Zero confirmations is the configuration where the confirmation manager is bypassed entirely,
+	// so it can never report an in-flight event - the connector's answer is all we have
+	mcm := &confirmationsmocks.Manager{}
+	es.confirmations = mcm
+	es.confirmationsRequired = 0
+
+	// The connector has scanned to 5000, but the last event it pushed to us is at 4950 and we have
+	// only committed to 4900. Applying 5000 would put that event behind its own listener's checkpoint
+	mfc := es.connector.(*ffcapimocks.API)
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{
+		Checkpoint:   &utCheckpointType{SomeSequenceNumber: 5000},
+		LastDetected: &utCheckpointType{SomeSequenceNumber: 4950},
+	}, ffcapi.ErrorReason(""), nil).Once()
+
+	cp := es.generateCheckpoint(ss, nil)
+	assert.Equal(t, &utCheckpointType{SomeSequenceNumber: 4900}, li.checkpoint)
+	assert.Equal(t, checkpointSourceEvent, li.checkpointSource)
+	assert.JSONEq(t, `{"someSequenceNumber":4900}`, string(cp.Listeners[*li.spec.ID]))
+
+	mfc.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+	mcm.AssertNotCalled(t, "CheckInFlight", mock.Anything)
+}
+
+func TestHWMAppliedWhenAllDetectedCommitted(t *testing.T) {
+
+	es := newTestEventStream(t, `{
+		"name": "ut_stream"
+	}`)
+
+	ss := &startedStreamState{}
+	ss.ctx, ss.cancelCtx = context.WithCancel(context.Background())
+	defer ss.cancelCtx()
+
+	li := newHWMTestListener(es, &utCheckpointType{SomeSequenceNumber: 4950})
+
+	mcm := &confirmationsmocks.Manager{}
+	es.confirmations = mcm
+	es.confirmationsRequired = 0
+
+	// We have committed everything the connector detected, so the scan position is safe to apply.
+	// This is the reason the high water mark route exists - an idle listener behind a busy chain
+	// must still make progress, or a restart replays from wherever it last saw an event
+	mfc := es.connector.(*ffcapimocks.API)
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{
+		Checkpoint:   &utCheckpointType{SomeSequenceNumber: 5000},
+		LastDetected: &utCheckpointType{SomeSequenceNumber: 4950},
+	}, ffcapi.ErrorReason(""), nil).Once()
+
+	cp := es.generateCheckpoint(ss, nil)
+	assert.Equal(t, &utCheckpointType{SomeSequenceNumber: 5000}, li.checkpoint)
+	assert.Equal(t, checkpointSourceHWM, li.checkpointSource)
+	assert.JSONEq(t, `{"someSequenceNumber":5000}`, string(cp.Listeners[*li.spec.ID]))
+
+	mfc.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+}
+
+func TestHWMNotAppliedWhenNothingCommitted(t *testing.T) {
+
+	es := newTestEventStream(t, `{
+		"name": "ut_stream"
+	}`)
+
+	ss := &startedStreamState{}
+	ss.ctx, ss.cancelCtx = context.WithCancel(context.Background())
+	defer ss.cancelCtx()
+
+	li := newHWMTestListener(es, nil)
+
+	mcm := &confirmationsmocks.Manager{}
+	es.confirmations = mcm
+	es.confirmationsRequired = 0
+
+	// We have committed nothing at all, so anything the connector has detected holds us back
+	mfc := es.connector.(*ffcapimocks.API)
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{
+		Checkpoint:   &utCheckpointType{SomeSequenceNumber: 5000},
+		LastDetected: &utCheckpointType{SomeSequenceNumber: 4950},
+	}, ffcapi.ErrorReason(""), nil).Once()
+
+	cp := es.generateCheckpoint(ss, nil)
+	assert.Nil(t, li.checkpoint)
+	_, hasEntry := cp.Listeners[*li.spec.ID]
+	assert.False(t, hasEntry)
+
+	mfc.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+}
+
+func TestHWMLegacyConnectorFallsBackToCheckInFlight(t *testing.T) {
+
+	es := newTestEventStream(t, `{
+		"name": "ut_stream"
+	}`)
+
+	ss := &startedStreamState{}
+	ss.ctx, ss.cancelCtx = context.WithCancel(context.Background())
+	defer ss.cancelCtx()
+
+	li := newHWMTestListener(es, &utCheckpointType{SomeSequenceNumber: 4900})
+
+	// Zero confirmations - the configuration in which the old guard was skipped entirely, because
+	// it was gated on confirmationsRequired > 0
+	mcm := &confirmationsmocks.Manager{}
+	es.confirmations = mcm
+	es.confirmationsRequired = 0
+
+	// The connector reports no LastDetected, so the confirmation manager is all we have
+	mfc := es.connector.(*ffcapimocks.API)
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{
+		Checkpoint: &utCheckpointType{SomeSequenceNumber: 5000},
+	}, ffcapi.ErrorReason(""), nil)
+
+	inFlight := mcm.On("CheckInFlight", li.spec.ID).Return(true).Once()
+	cp := es.generateCheckpoint(ss, nil)
+	assert.Equal(t, &utCheckpointType{SomeSequenceNumber: 4900}, li.checkpoint)
+	assert.JSONEq(t, `{"someSequenceNumber":4900}`, string(cp.Listeners[*li.spec.ID]))
+
+	// Once nothing is in flight it applies
+	inFlight.Unset()
+	li.lastCheckpoint = nil // force staleness rather than sleeping
+	mcm.On("CheckInFlight", li.spec.ID).Return(false).Once()
+	cp = es.generateCheckpoint(ss, nil)
+	assert.Equal(t, &utCheckpointType{SomeSequenceNumber: 5000}, li.checkpoint)
+	assert.Equal(t, checkpointSourceHWM, li.checkpointSource)
+	assert.JSONEq(t, `{"someSequenceNumber":5000}`, string(cp.Listeners[*li.spec.ID]))
+
+	mfc.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+}
+
+func TestHWMQueriesConnectorBeforeDeciding(t *testing.T) {
+
+	es := newTestEventStream(t, `{
+		"name": "ut_stream"
+	}`)
+
+	ss := &startedStreamState{}
+	ss.ctx, ss.cancelCtx = context.WithCancel(context.Background())
+	defer ss.cancelCtx()
+
+	li := newHWMTestListener(es, &utCheckpointType{SomeSequenceNumber: 4900})
+
+	mcm := &confirmationsmocks.Manager{}
+	es.confirmations = mcm
+	es.confirmationsRequired = 1
+
+	// The connector must be asked before we decide, not after we have already ruled the update out.
+	// Anything we check beforehand is stale by the time the answer arrives, so the answer has to be
+	// what the decision is made against
+	queried := false
+	mfc := es.connector.(*ffcapimocks.API)
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		assert.False(t, queried)
+		queried = true
+	}).Return(&ffcapi.EventListenerHWMResponse{
+		Checkpoint: &utCheckpointType{SomeSequenceNumber: 5000},
+	}, ffcapi.ErrorReason(""), nil).Once()
+	mcm.On("CheckInFlight", li.spec.ID).Run(func(args mock.Arguments) {
+		assert.True(t, queried, "the connector must be queried before the in-flight check")
+	}).Return(true).Once()
+
+	es.generateCheckpoint(ss, nil)
+	assert.True(t, queried)
+	assert.Equal(t, &utCheckpointType{SomeSequenceNumber: 4900}, li.checkpoint)
+
+	mfc.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+}
+
+func TestNoHWMQueryForBlockListener(t *testing.T) {
+
+	es := newTestEventStream(t, `{
+		"name": "ut_stream"
+	}`)
+
+	ss := &startedStreamState{}
+	ss.ctx, ss.cancelCtx = context.WithCancel(context.Background())
+	defer ss.cancelCtx()
+
+	// A block listener is handled entirely inside our own confirmation manager, and is never passed
+	// to the connector - so a stale checkpoint must not turn into a query for a listener ID the
+	// connector has never heard of
+	li := newHWMTestListener(es, nil)
+	li.spec.Type = &apitypes.ListenerTypeBlocks
+
+	mcm := &confirmationsmocks.Manager{}
+	es.confirmations = mcm
+	es.confirmationsRequired = 1
+
+	mfc := es.connector.(*ffcapimocks.API)
+	cp := es.generateCheckpoint(ss, nil)
+	_, hasEntry := cp.Listeners[*li.spec.ID]
+	assert.False(t, hasEntry)
+
+	mfc.AssertNotCalled(t, "EventListenerHWM", mock.Anything, mock.Anything)
+	mcm.AssertNotCalled(t, "CheckInFlight", mock.Anything)
+}
+
+func TestEventBehindHWMCheckpointIsDelivered(t *testing.T) {
+
+	es := newTestEventStream(t, `{
+		"name": "ut_stream"
+	}`)
+
+	li := newHWMTestListener(es, &utCheckpointType{SomeSequenceNumber: 5000})
+	li.checkpointSource = checkpointSourceHWM
+
+	e := &ffcapi.ListenerEvent{
+		Checkpoint: &utCheckpointType{SomeSequenceNumber: 4950},
+		Event:      &ffcapi.Event{ID: ffcapi.EventID{ListenerID: li.spec.ID, BlockNumber: 4950}},
+	}
+
+	// Behind a high water mark checkpoint we cannot tell a re-detection apart from an event emitted
+	// before, but arriving after, we applied the connector's scan position. A duplicate is absorbed
+	// by FireFly on protocol ID, a drop is not - so we deliver
+	l, ewc := es.checkConfirmedEventForBatch(e)
+	assert.Equal(t, li, l)
+	assert.NotNil(t, ewc)
+	assert.Equal(t, uint64(4950), ewc.Event.ID.BlockNumber.Uint64())
+
+	// Behind the position of an event the receiver acked, we know we already delivered it
+	li.checkpointSource = checkpointSourceEvent
+	l, ewc = es.checkConfirmedEventForBatch(e)
+	assert.Nil(t, l)
+	assert.Nil(t, ewc)
 }
 
 func TestHWMCheckpointPersistedDuringCatchup(t *testing.T) {

--- a/internal/events/listener.go
+++ b/internal/events/listener.go
@@ -26,12 +26,22 @@ import (
 	"github.com/hyperledger-firefly/transaction-manager/pkg/ffcapi"
 )
 
+// checkpointSource records which of the two routes set a listener's checkpoint.
+// Matters when an event turns up behind that checkpoint - see checkConfirmedEventForBatch.
+type checkpointSource int
+
+const (
+	checkpointSourceEvent checkpointSource = iota // an event we delivered and the receiver acked
+	checkpointSourceHWM                           // from the connector's scan position
+)
+
 type listener struct {
-	es             *eventStream
-	spec           *apitypes.Listener
-	lastCheckpoint *fftypes.FFTime
-	checkpoint     ffcapi.EventListenerCheckpoint
-	started        bool // protected by es.mux - set only once the connector has accepted the listener, so we never query the connector for a listener it does not know
+	es               *eventStream
+	spec             *apitypes.Listener
+	lastCheckpoint   *fftypes.FFTime
+	checkpoint       ffcapi.EventListenerCheckpoint
+	started          bool             // protected by es.mux - set only once the connector has accepted the listener, so we never query the connector for a listener it does not know
+	checkpointSource checkpointSource // protected by es.mux
 }
 
 type blockListenerAddRequest struct {

--- a/pkg/ffcapi/api.go
+++ b/pkg/ffcapi/api.go
@@ -80,6 +80,7 @@ type API interface {
 	EventListenerRemove(ctx context.Context, req *EventListenerRemoveRequest) (*EventListenerRemoveResponse, ErrorReason, error)
 
 	// EventListenerHWM queries the current high water mark checkpoint for a listener. Called at regular intervals when there are no events in flight for a listener, to ensure checkpoint are written regularly even when there is no activity
+	// ** See important notes on EventListenerHWMResponse docs **
 	EventListenerHWM(ctx context.Context, req *EventListenerHWMRequest) (*EventListenerHWMResponse, ErrorReason, error)
 
 	// EventStreamNewCheckpointStruct used during checkpoint restore, to get the specific into which to restore the JSON bytes

--- a/pkg/ffcapi/event_listener_hwm.go
+++ b/pkg/ffcapi/event_listener_hwm.go
@@ -25,7 +25,34 @@ type EventListenerHWMRequest struct {
 	ListenerID *fftypes.UUID `json:"listenerId"`
 }
 
+// EventListenerHWM return value.
+//
+// Important:
+//
+// The connector SHOULD implement LastDetected as well as Checkpoint on the response returned.
+//
+// Checkpoint is how far the connector has scanned.
+// LastDetected is the checkpoint of the last event it pushed to FFTM.
+//
+// These differ, because the connector can scan past events that are still sat in the
+// channel unread - FFTM cannot see those for itself, so it must be told.
+//
+// FFTM applies Checkpoint only once everything up to LastDetected has been delivered and acked.
+//
+// The connector needs to hold in memory a LastDetected value (to return when asked) that
+// is updated BEFORE updating the value it returns for the scan position.
+// When building the response for EventListenerHWM() read the scan position first, then
+// the last detected (or guard them both under a single mutex).
+//
+// Following these simple rules ensures FFTM never moves the checkpoint past an event
+// that is still in flight.
+//
+// Setting nil LastDetected is correct when nothing has been pushed for this listener.
+//
+// A connector that never implements LastDetected (always nil) is functional, but accepts
+// a risk of a checkpoint being persisted past events FFTM has not yet acknowledged.
 type EventListenerHWMResponse struct {
-	Checkpoint EventListenerCheckpoint `json:"checkpoint"`
-	Catchup    bool                    `json:"catchup,omitempty"` // informational only - informs an operator that the stream is catching up
+	Checkpoint   EventListenerCheckpoint `json:"checkpoint"`             // how far the connector has scanned
+	Catchup      bool                    `json:"catchup,omitempty"`      // informational only - informs an operator that the stream is catching up
+	LastDetected EventListenerCheckpoint `json:"lastDetected,omitempty"` // the checkpoint of the last event it pushed to FFTM
 }

--- a/pkg/ffcapi/event_listener_hwm.go
+++ b/pkg/ffcapi/event_listener_hwm.go
@@ -37,6 +37,9 @@ type EventListenerHWMRequest struct {
 // These differ, because the connector can scan past events that are still sat in the
 // channel unread - FFTM cannot see those for itself, so it must be told.
 //
+// So the checkpoint returned could be ahead of last detected (if we ever detected an event),
+// but never behind.
+//
 // FFTM applies Checkpoint only once everything up to LastDetected has been delivered and acked.
 //
 // The connector needs to hold in memory a LastDetected value (to return when asked) that


### PR DESCRIPTION
This fixes a scenario where an event stream listener could silently drop events.
The scenario has been observed in practice when there are multiple listeners on a single event stream, and those listeners are catching up to the head while redelivery is occurring delaying acknowledgment of events detected during catchup by one of those listeners.

Each listener's checkpoint within the overall event stream advances two ways:

1. From an event delivered and acked by the application
2. From FFTM poling the collector with `EventListenerHWM` to check the position the connector's **scan** has reached

The second can be ahead of the first, as the connector pushes events into a channel in FFTM and continues to scan forwards to find more events while FFTM assembles those events into a batch, and delivers that batch awaiting ack.

The guards against moving the checkpoint forwards while those events were pending acknowledgment were not strong enough in FFTM.

## Fix architecture

A minimal **additive** change is made to the FFCAPI on the return value to `EventListenerHWMResponse()`, so that it not only returns the scan position, but also the checkpoint position of the highest event passed to the FFTM channel.

When a connector implements that simple contract (separate PR to EVMConnect), the changes in this FFTM PR provide an absolute assurance that the checkpoint is never moved forward by the scan interval, while there are uncommitted deliveries that have been pushed from the connector to FFTM.

https://github.com/hyperledger-firefly/transaction-manager/blob/5e887b9fb1037ceaae58af81c307b89a47240976/pkg/ffcapi/event_listener_hwm.go#L28-L58

Also included:

- **Block listeners** no longer take the HWM route. They're handled inside FFTM's own confirmation manager, so we were querying the connector with listener IDs it has never heard of.
- **Never silently drop** An event arriving behind an HWM-derived checkpoint is now delivered with a warning. We can't distinguish it from a genuine re-detection, and a duplicate is recoverable
    - Note FireFly core de-duplicates on protocol ID, so this does not mean application redelivery in practice

